### PR TITLE
Fixed 1 issue of type: PYTHON_E402 throughout 1 file in repo.

### DIFF
--- a/migrations/versions/2019_04_04_f972b83f1baa_tag_mode.py
+++ b/migrations/versions/2019_04_04_f972b83f1baa_tag_mode.py
@@ -1,3 +1,4 @@
+from stickerfinder.helper.tag_mode import TagMode
 """Tag mode migration.
 
 Revision ID: f972b83f1baa
@@ -15,7 +16,6 @@ from sqlalchemy.orm.session import Session
 parent_dir = os.path.abspath(os.path.join(os.getcwd()))
 sys.path.append(parent_dir)
 from stickerfinder.models import Chat # noqa
-from stickerfinder.helper.tag_mode import TagMode
 
 # revision identifiers, used by Alembic.
 revision = 'f972b83f1baa'


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.