### PR TITLE
Fixed 2 issues of type: PYTHON_W391 throughout 2 files in repo.

### DIFF
--- a/migrations/versions/2019_04_04_f972b83f1baa_tag_mode.py
+++ b/migrations/versions/2019_04_04_f972b83f1baa_tag_mode.py
@@ -59,4 +59,3 @@ def downgrade():
         (full_sticker_set IS TRUE AND tagging_random_sticker IS FALSE AND fix_single_sticker IS FALSE) OR \
         (full_sticker_set IS FALSE AND tagging_random_sticker IS FALSE AND fix_single_sticker IS FALSE)
     """)
-

--- a/stickerfinder/telegram/callback_handlers/report.py
+++ b/stickerfinder/telegram/callback_handlers/report.py
@@ -68,4 +68,3 @@ def handle_report_next(session, action, query, payload, chat, tg_chat):
         call_tg_func(query.message, 'edit_reply_markup', [], {'reply_markup': keyboard})
     except: # noqa
         return
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.