### PR TITLE
Fixed 4 issues of type: PYTHON_F401 throughout 4 files in repo.

### DIFF
--- a/migrations/versions/2018_11_30_7ddf4da81c22_rename_default_language.py
+++ b/migrations/versions/2018_11_30_7ddf4da81c22_rename_default_language.py
@@ -6,7 +6,6 @@ Create Date: 2018-11-30 05:16:51.439164
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.

--- a/migrations/versions/2018_11_30_b179e344cc02_check_constraints.py
+++ b/migrations/versions/2018_11_30_b179e344cc02_check_constraints.py
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 
 import os
 import sys
-from sqlalchemy import or_, and_
+from sqlalchemy import or_
 from sqlalchemy.orm.session import Session
 # Set system path, so alembic is capable of finding the stickerfinder module
 parent_dir = os.path.abspath(os.path.join(os.getcwd(), "..", "stickerfinder"))

--- a/migrations/versions/2019_04_04_9fa624eb51ab_cascade_on_chat_sticker_file_id.py
+++ b/migrations/versions/2019_04_04_9fa624eb51ab_cascade_on_chat_sticker_file_id.py
@@ -6,7 +6,6 @@ Create Date: 2019-04-04 19:01:02.184006
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '9fa624eb51ab'

--- a/migrations/versions/2019_04_11_7d9cf9d4337c_.py
+++ b/migrations/versions/2019_04_11_7d9cf9d4337c_.py
@@ -6,7 +6,6 @@ Create Date: 2019-04-11 13:08:11.570425
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        